### PR TITLE
[fix] Update README for shadcn-vue CLI fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,14 @@ bun run preview
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information on deploying your Nuxt 3 application.
 
 See the [Shadcn-vue docs](https://www.shadcn-vue.com/docs/introduction.html) to see how to use it.
+
+**[FIX 10 Jun 2024]** Currently shadcn-vue@latest is broken and does not add the components correctly for Nuxt. They end up in a folder somewhere outside your working directory. Please use v0.10.4 until this issue has been fixed by the shadcn-vue team. 
+
+***bunx*** may also not work properly, if so using ***npx*** may be preferable for adding components.
+
 Example: 
 ```
-npx shadcn-vue@latest add COMPONENT_NAME
+npx shadcn-vue@v0.10.4 add COMPONENT_NAME
 ```
 Buttons and Tooltips are already included
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 -   **🍍 Pinia Store:** Lightweight state management solution. 
 -   **⌨️ TypeScript:** Enables type safety and improved development experience.
 -   **💨 Tailwind:** Provides a utility-first CSS framework for rapid styling.
+-   **🛡️ Nuxt-Security:** Automatically configure your app to follow OWASP security patterns and principles.
 -   **💾 Supabase (optional):** Supabase is an open source Firebase alternative. (See the supabase branch)
 
 ## Getting Started

--- a/components.json
+++ b/components.json
@@ -3,7 +3,7 @@
   "style": "default",
   "typescript": true,
   "tailwind": {
-    "config": "tailwind.config.js",
+    "config": "tailwind.config.ts",
     "css": "assets/css/tailwind.css",
     "baseColor": "neutral",
     "cssVariables": true


### PR DESCRIPTION
- Change README to recommend users to use shadcn-vue@v0.10.4 instead of latest due to breaking changes for Nuxt
- Includes components.json tailwind path fix